### PR TITLE
Specify confirmed working Blender version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Character Templates for Coop Deluxe
 These are character templates made for player characters that appear in **Super Mario 64 Deluxe**. It adds many QOL features that make editing your models easier.
 
-*We recommended using Blender v3.6*
+*Confirmed working on Blender v4.2.20.*
 
 *Fast64 is required for this `.blend` file. We recommend you download one of these 2 forks:*
 


### PR DESCRIPTION
This README needs to specify an exact-supported Blender version. I just spent multiple hours trying different versions from Blender 3.2+ to Blender 4.0+ and they either don't load materials, don't find the bgl Python module or error out with wrongly-cased variable names on export.